### PR TITLE
Fix small typo in instructions to install msfrpc

### DIFF
--- a/msfHelper.py
+++ b/msfHelper.py
@@ -16,7 +16,7 @@ except:
  print "Please install msfrpc from https://github.com/SpiderLabs/msfrpc/tree/master/python-msfrpc"
  print "\n"
  print "cd /tmp && git clone https://github.com/SpiderLabs/msfrpc"
- print "cd msfrpc && cd cd python-msfrpc && python setup.py install"
+ print "cd msfrpc && cd python-msfrpc && python setup.py install"
  print "pip install msgpack-python"
  print "\n"
  sys.exit()


### PR DESCRIPTION
Removes the double `cd` in the instructions for msfrpc, closes #18 